### PR TITLE
Fix README cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This plugin can send temperature and humidity detected by your Nature Remo.
 ## Synopsis
 
 ```
-mackerel-plugin-nature-remo -access-key=<access-key>
+mackerel-plugin-nature-remo -access-token=<access-token>
 ```
 
 ## Example of mackerel-agent.conf
 
 ```
 [plugin.metrics.NatureRemo]
-command = "/path/to/mackerel-plugin-nature-remo -access-key=..."
+command = "/path/to/mackerel-plugin-nature-remo -access-token=..."
 ```


### PR DESCRIPTION
@papix Hello :smile:
In README, wrong parameter `access-key` is used. And I fixed it to `access-token`.

```
$ mackerel-plugin-nature-remo -access-key=xxx
flag provided but not defined: -access-key
Usage of mackerel-plugin-nature-remo:
  -access-token string
    	Access token
  -metric-key-prefix string
    	Metric key prefix (default "NatureRemo")
  -tempfile string
    	Temp file name
```